### PR TITLE
Show success screen upon successful upload (#23)

### DIFF
--- a/frontend/src/app/components/CheckMarkIcon.tsx
+++ b/frontend/src/app/components/CheckMarkIcon.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+const CheckMarkIcon = () => {
+  return (
+    <div className="bg-green-600 rounded-full p-4 mb-6 shadow-lg">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-12 w-12 text-white"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
+          <path
+            fillRule="evenodd"
+            d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 111.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </div>
+  )
+}
+
+export default CheckMarkIcon;

--- a/frontend/src/app/components/Success.tsx
+++ b/frontend/src/app/components/Success.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import React from "react";
+import CheckMarkIcon from "./CheckMarkIcon";
 
 interface SuccessPageProps {
   message: string;
@@ -19,21 +20,7 @@ const SuccessPage: React.FC<SuccessPageProps> = ({ message, buttonText, redirect
   return (
     <div className="min-h-screen flex flex-col justify-center items-center bg-black text-white px-4 text-center">
       {/* Green checkmark */}
-      <div className="bg-green-600 rounded-full p-4 mb-6 shadow-lg">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          className="h-12 w-12 text-white"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-        >
-          <path
-            fillRule="evenodd"
-            d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 111.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
-            clipRule="evenodd"
-          />
-        </svg>
-      </div>
-
+      <CheckMarkIcon />
       {/* Message */}
       <h2 className="text-2xl font-semibold mb-4 text-green-400">{message}</h2>
 

--- a/frontend/src/app/components/Success.tsx
+++ b/frontend/src/app/components/Success.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import React from "react";
+
+interface SuccessPageProps {
+  message: string;
+  buttonText: string;
+  redirectPath: string;
+}
+
+const SuccessPage: React.FC<SuccessPageProps> = ({ message, buttonText, redirectPath }) => {
+  const router = useRouter();
+
+  const handleRedirect = () => {
+    router.push(redirectPath);
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col justify-center items-center bg-black text-white px-4 text-center">
+      {/* Green checkmark */}
+      <div className="bg-green-600 rounded-full p-4 mb-6 shadow-lg">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-12 w-12 text-white"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
+          <path
+            fillRule="evenodd"
+            d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 111.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </div>
+
+      {/* Message */}
+      <h2 className="text-2xl font-semibold mb-4 text-green-400">{message}</h2>
+
+      {/* Redirect button */}
+      <button
+        onClick={handleRedirect}
+        className="mt-2 bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-6 rounded-xl shadow-md transition duration-300"
+      >
+        {buttonText}
+      </button>
+    </div>
+  );
+};
+
+export default SuccessPage;

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -2,11 +2,13 @@
 
 import React, { useState, DragEvent, FormEvent } from "react";
 import { uploadFile } from "../services/upload";
+import SuccessPage from "../components/Success";
 
 export default function Upload() {
   const [file, setFile] = useState<File | null>(null);
   const [fileName, setFileName] = useState<string | null>(null);
   const [dragActive, setDragActive] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
 
   const handleDrop = (e: DragEvent<HTMLLabelElement>) => {
     e.preventDefault();
@@ -42,11 +44,24 @@ export default function Upload() {
     try {
       const orgId = 1; // Will replace this with the actual organisation ID later
       const response = await uploadFile(file, orgId.toString());
+
+      setShowSuccess(true);
+
       console.log("File uploaded successfully:", response.data);
     } catch (error) {
       console.error("Error uploading file:", error);
     }
   };
+
+  if (showSuccess) {
+    return (
+      <SuccessPage
+        message="File uploaded successfully!"
+        buttonText="Back to Dashboard"
+        redirectPath="/dashboard" 
+      />
+    );
+  }
 
   return (
     <form
@@ -59,7 +74,9 @@ export default function Upload() {
         onDrop={handleDrop}
         htmlFor="file-upload"
         className={`w-full max-w-md flex flex-col items-center justify-center border-2 border-dashed rounded-2xl p-6 cursor-pointer transition-colors ${
-          dragActive ? "border-blue-400 bg-gray-800" : "border-gray-600 bg-black"
+          dragActive
+            ? "border-blue-400 bg-gray-800"
+            : "border-gray-600 bg-black"
         }`}
       >
         <svg
@@ -79,7 +96,8 @@ export default function Upload() {
         <p className="text-gray-300 text-center">
           {fileName ? (
             <>
-              <span className="text-green-400 font-medium">Selected:</span> {fileName}
+              <span className="text-green-400 font-medium">Selected:</span>{" "}
+              {fileName}
             </>
           ) : (
             "Drag & drop your file here or click to choose one"


### PR DESCRIPTION
This pull request depends on #23 (feat/frontend-upload-status-#23) and it includes the following:

- Creating a reusable success page with dynamic message, redirect url and botton text that are passed as parameters
- Using the success component in the upload screen through a state that is set to true upon successful upload in order to render the success component

Closes #24 